### PR TITLE
Use CTE instead of temporary tables to query for pending downloads

### DIFF
--- a/apps/postgresql-server/schema/mediawords.sql
+++ b/apps/postgresql-server/schema/mediawords.sql
@@ -24,7 +24,7 @@ CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
 DECLARE
     -- Database schema version number (same as a SVN revision number)
     -- Increase it by 1 if you make major database schema changes.
-    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4733;
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4734;
 BEGIN
 
     -- Update / set database schema version
@@ -873,6 +873,10 @@ CREATE TRIGGER downloads_pending_test_referenced_download_trigger
     FOR EACH ROW
     EXECUTE PROCEDURE test_referenced_download_trigger('parent');
 
+-- Used by crawler provider to find prioritized downloads for each host
+CREATE INDEX downloads_pending_host_priority_downloads_id
+    ON downloads_pending (host, priority, downloads_id DESC NULLS LAST);
+
 
 CREATE TABLE downloads_success
     PARTITION OF downloads (
@@ -1447,42 +1451,6 @@ end;
 
 $$ language plpgsql;
 
--- efficiently query downloads_pending for the latest downloads_id per host.  postgres is not able to do this through
--- its normal query planning (it just does an index scan of the whole index).  this turns a query that 
--- takes ~22 seconds for a 100 million row table into one that takes ~0.25 seconds
-create or replace function get_downloads_for_queue() returns table(downloads_id bigint) as $$
-declare
-    pending_host record;
-begin
-    -- quick temp copy without dead row issues for querying in loop body below
-    create temporary table qd on commit drop as select * from queued_downloads;
-
-    create temporary table pending_downloads (downloads_id bigint) on commit drop;
-    for pending_host in
-            WITH RECURSIVE t AS (
-               (SELECT host FROM downloads_pending ORDER BY host LIMIT 1)
-               UNION ALL
-               SELECT (SELECT host FROM downloads_pending WHERE host > t.host ORDER BY host LIMIT 1)
-               FROM t
-               WHERE t.host IS NOT NULL
-               )
-            SELECT host FROM t WHERE host IS NOT NULL
-        loop
-            insert into pending_downloads
-                select dp.downloads_id
-                    from downloads_pending dp
-                        left join qd on ( dp.downloads_id = qd.downloads_id )
-                    where 
-                        host = pending_host.host and
-                        qd.downloads_id is null
-                    order by priority, downloads_id desc nulls last
-                    limit 1;
-        end loop;
-
-    return query select pd.downloads_id from pending_downloads pd;
- end;
-
-$$ language plpgsql;
 
 --
 -- Extracted plain text from every download

--- a/apps/postgresql-server/schema/migrations/mediawords-4733-4734.sql
+++ b/apps/postgresql-server/schema/migrations/mediawords-4733-4734.sql
@@ -1,0 +1,48 @@
+--
+-- This is a Media Cloud PostgreSQL schema difference file (a "diff") between schema
+-- versions 4733 and 4734.
+--
+-- If you are running Media Cloud with a database that was set up with a schema version
+-- 4733, and you would like to upgrade both the Media Cloud and the
+-- database to be at version 4734, import this SQL file:
+--
+--     psql mediacloud < mediawords-4733-4734.sql
+--
+-- You might need to import some additional schema diff files to reach the desired version.
+--
+--
+-- 1 of 2. Import the output of 'apgdiff':
+--
+
+
+CREATE INDEX IF NOT EXISTS downloads_pending_host_priority_downloads_id
+    ON downloads_pending (host, priority, downloads_id DESC NULLS LAST);
+
+
+DROP FUNCTION get_downloads_for_queue();
+
+
+--
+-- 2 of 2. Reset the database version.
+--
+
+CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
+DECLARE
+
+    -- Database schema version number (same as a SVN revision number)
+    -- Increase it by 1 if you make major database schema changes.
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4734;
+
+BEGIN
+
+    -- Update / set database schema version
+    DELETE FROM database_variables WHERE name = 'database-schema-version';
+    INSERT INTO database_variables (name, value) VALUES ('database-schema-version', MEDIACLOUD_DATABASE_SCHEMA_VERSION::int);
+
+    return true;
+
+END;
+$$
+LANGUAGE 'plpgsql';
+
+SELECT set_database_schema_version();


### PR DESCRIPTION
Temporary tables fill up "pg_class" and "pg_attribute" so let's reduce those.

As of PostgreSQL 11, all CTEs get materialized first, thus making CTE a safe replacement for a temporary table.

Replaced the recursive trick with LATERAL join to get a single download for each parameter host.

Removed the "queued_downloads" copying as it's unclear how a copy could have prevented issues with dead rows. Query plans for the updated query seem to be choosing sequential scans when the number of rows in "queued_downloads" is low and index scans with a bigger number of rows.

Sample query plan:

```
                                                                                                       QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=73.85..152.91 rows=100 width=8) (actual time=207.795..833.113 rows=5 loops=1)
   CTE pending_hosts
     ->  CTE Scan on t t_1  (cost=71.27..73.29 rows=100 width=32) (actual time=197.140..792.443 rows=5 loops=1)
           Filter: (host IS NOT NULL)
           Rows Removed by Filter: 1
           CTE t
             ->  Recursive Union  (cost=0.56..71.27 rows=101 width=32) (actual time=197.137..792.430 rows=6 loops=1)
                   ->  Limit  (cost=0.56..0.66 rows=1 width=21) (actual time=197.133..197.134 rows=1 loops=1)
                         ->  Index Only Scan using downloads_pending_host_priority_downloads_id on downloads_pending downloads_pending_2  (cost=0.56..868758.95 rows=8471159 width=21) (actual time=197.132..197.132 rows=1 loops=1)
                               Heap Fetches: 93093
                   ->  WorkTable Scan on t  (cost=0.00..6.86 rows=10 width=32) (actual time=99.211..99.211 rows=1 loops=6)
                         Filter: (host IS NOT NULL)
                         Rows Removed by Filter: 0
                         SubPlan 1
                           ->  Limit  (cost=0.56..0.67 rows=1 width=21) (actual time=119.045..119.046 rows=1 loops=5)
                                 ->  Index Only Scan using downloads_pending_host_priority_downloads_id on downloads_pending downloads_pending_1  (cost=0.56..298862.22 rows=2823720 width=21) (actual time=119.043..119.043 rows=1 loops=5)
                                       Index Cond: (host > t.host)
                                       Heap Fetches: 601389
   ->  CTE Scan on pending_hosts  (cost=0.00..2.00 rows=100 width=32) (actual time=197.150..792.459 rows=5 loops=1)
   ->  Limit  (cost=0.56..0.76 rows=1 width=31) (actual time=8.126..8.128 rows=1 loops=5)
         ->  Nested Loop Anti Join  (cost=0.56..277095.31 rows=1411859 width=31) (actual time=8.125..8.125 rows=1 loops=5)
               Join Filter: (queued_downloads.downloads_id = downloads_pending.downloads_id)
               ->  Index Only Scan using downloads_pending_host_priority_downloads_id on downloads_pending  (cost=0.56..149876.83 rows=1411860 width=31) (actual time=7.623..7.623 rows=1 loops=5)
                     Index Cond: (host = pending_hosts.host)
                     Heap Fetches: 72441
               ->  Materialize  (cost=0.00..151.09 rows=6 width=8) (actual time=0.499..0.499 rows=0 loops=5)
                     ->  Seq Scan on queued_downloads  (cost=0.00..151.06 rows=6 width=8) (actual time=2.483..2.483 rows=0 loops=1)
 Planning Time: 2.722 ms
 Execution Time: 833.250 ms
(29 rows)
```

Runs in a comparable speed or faster than the previous implementation with temporary tables.

Lastly, add an undocumented index from production to the repository schema.