### PR TITLE
add .decoded_json() method to Response

### DIFF
--- a/apps/common/src/python/mediawords/solr/request.py
+++ b/apps/common/src/python/mediawords/solr/request.py
@@ -12,7 +12,7 @@ from furl import furl
 from mediawords.solr.params import SolrParams
 from mediawords.util.config.common import CommonConfig
 from mediawords.util.log import create_logger
-from mediawords.util.parse_json import decode_json, encode_json
+from mediawords.util.parse_json import encode_json
 from mediawords.util.perl import decode_object_from_bytes_if_needed
 from mediawords.util.web.user_agent import UserAgent, Response, Request
 
@@ -81,7 +81,7 @@ def __wait_for_solr_to_start(config: Optional[CommonConfig]) -> None:
                 raise Exception("Response is empty.")
 
             try:
-                result = decode_json(response.decoded_content())
+                result = response.decoded_json()
             except Exception as ex:
                 raise Exception(f"Unable to decode response: {ex}")
 
@@ -128,7 +128,7 @@ def __solr_error_message_from_response(response: Response) -> str:
 
                 solr_response_json = {}
                 try:
-                    solr_response_json = decode_json(solr_response_maybe_json)
+                    solr_response_json = response.decoded_json()
                 except Exception as ex:
                     log.debug(f"Unable to parse Solr error response: {ex}; raw response: {solr_response_maybe_json}")
 

--- a/apps/common/src/python/mediawords/util/extract_article_from_page.py
+++ b/apps/common/src/python/mediawords/util/extract_article_from_page.py
@@ -5,7 +5,7 @@ from furl import furl
 from mediawords.util.config.common import CommonConfig
 from mediawords.util.log import create_logger
 from mediawords.util.network import wait_for_tcp_port_to_open
-from mediawords.util.parse_json import encode_json, decode_json
+from mediawords.util.parse_json import encode_json
 from mediawords.util.perl import decode_object_from_bytes_if_needed
 from mediawords.util.process import fatal_error
 from mediawords.util.web.user_agent import Request, UserAgent
@@ -114,8 +114,7 @@ def extract_article_html_from_page_html(content: str, config: Optional[CommonCon
             f"Extraction of {len(content)} characters; failed; last error: {http_response.decoded_content()}"
         )
 
-    response_json = http_response.decoded_content()
-    response = decode_json(response_json)
+    response = http_response.decoded_json()
 
     assert 'extracted_html' in response, "Response is expected to have 'extracted_html' key."
     assert 'extractor_version' in response, "Response is expected to have 'extractor_version' key."

--- a/apps/common/src/python/mediawords/util/web/user_agent/response/response.py
+++ b/apps/common/src/python/mediawords/util/web/user_agent/response/response.py
@@ -9,6 +9,7 @@ import requests
 
 from mediawords.util.log import create_logger
 from mediawords.util.perl import decode_object_from_bytes_if_needed
+from mediawords.util.parse_json import decode_json
 from mediawords.util.web.user_agent.request.request import Request
 
 log = create_logger(__name__)
@@ -199,6 +200,16 @@ class Response(object):
         """Return content in UTF-8 content while assuming that the raw data is in UTF-8."""
         # FIXME how do we do this?
         return self.decoded_content()
+
+    def decoded_json(self) -> Union[dict, list]:
+        """Return content as JSON object(s) assuming it's formatted appropriately"""
+        if self.content_type() and 'json' not in self.content_type():
+            log.warning(F"Content-Type header ({self.content_type()}) is not json for {self.__requests_response.url}")
+        try:
+            return decode_json(self.decoded_content())
+        except Exception as ex:
+            raise McUserAgentResponseException(F"Response from {self.__requests_response.url} not parseable to JSON: "
+                                               F"{str(ex)}")
 
     def status_line(self) -> str:
         """Return HTTP status line, e.g. "200 OK" or "418"."""

--- a/apps/crawler-fetcher/src/python/crawler_fetcher/handlers/feed_podcast.py
+++ b/apps/crawler-fetcher/src/python/crawler_fetcher/handlers/feed_podcast.py
@@ -6,7 +6,6 @@ from furl import furl
 from mediawords.db import DatabaseHandler
 from mediawords.job import JobBroker
 from mediawords.util.log import create_logger
-from mediawords.util.parse_json import decode_json
 from mediawords.util.web.user_agent import UserAgent
 
 from crawler_fetcher.handlers.feed_syndicated import DownloadFeedSyndicatedHandler
@@ -48,7 +47,7 @@ def _get_feed_url_from_itunes_podcasts_url(url: str) -> str:
         return url
 
     try:
-        res_dict = decode_json(res.decoded_content())
+        res_dict = res.decoded_json()
         if not isinstance(res_dict, dict):
             raise Exception("Result is not a dictionary")
     except Exception as ex:

--- a/apps/crawler-fetcher/tests/python/setup_univision_test.py
+++ b/apps/crawler-fetcher/tests/python/setup_univision_test.py
@@ -6,7 +6,6 @@ import pytest
 
 from mediawords.db import connect_to_db
 from mediawords.test.db.create import create_download_for_feed
-from mediawords.util.parse_json import decode_json
 from mediawords.util.web.user_agent import UserAgent
 
 from crawler_fetcher.config import CrawlerConfig
@@ -120,7 +119,7 @@ class AbstractUnivisionTest(object, metaclass=abc.ABCMeta):
         json_string = response.decoded_content()
         assert json_string, 'JSON response is not empty'
 
-        json = decode_json(json_string)
+        json = response.decoded_json()
         assert json.get('status', None) == 'success', "JSON response was successful"
         assert 'data' in json, 'JSON response has "data" key'
 

--- a/apps/facebook-fetch-story-stats/src/python/facebook_fetch_story_stats/__init__.py
+++ b/apps/facebook-fetch-story-stats/src/python/facebook_fetch_story_stats/__init__.py
@@ -7,7 +7,6 @@ from furl import furl
 
 from mediawords.db import DatabaseHandler
 from mediawords.util.log import create_logger
-from mediawords.util.parse_json import decode_json
 from mediawords.util.perl import decode_object_from_bytes_if_needed
 from mediawords.util.url import is_http_url, fix_common_url_mistakes, canonical_url
 from mediawords.util.web.user_agent import UserAgent
@@ -157,7 +156,7 @@ def _api_request(node: str, params: Dict[str, Union[str, List[str]]], config: Fa
             raise McFacebookSoftFailureException("Decoded content is empty.")
 
         try:
-            data = decode_json(decoded_content)
+            data = response.decoded_json()
         except Exception as ex:
 
             if 'something went wrong' in decoded_content:

--- a/apps/topics-mine/src/python/topics_mine/posts/brandwatch_twitter.py
+++ b/apps/topics-mine/src/python/topics_mine/posts/brandwatch_twitter.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, urlparse, quote
 import requests_mock
 
 from mediawords.util.config import env_value
-from mediawords.util.parse_json import decode_json, encode_json
+from mediawords.util.parse_json import encode_json
 from mediawords.util.web.user_agent import UserAgent
 from mediawords.util.web.user_agent.request.request import Request
 from mediawords.util.log import create_logger
@@ -110,9 +110,7 @@ def _get_api_key() -> str:
     if not response.is_success():
         raise McPostsBWTwitterDataException("error fetching posts: " + response.decoded_content())
 
-    json = response.decoded_content()
-
-    data = dict(decode_json(json))
+    data = dict(response.decoded_json())
 
     try:
         _get_api_key.api_key = data['access_token']
@@ -158,9 +156,7 @@ class BrandwatchTwitterPostFetcher(AbstractPostFetcher):
         if not response.is_success():
             raise McPostsBWTwitterDataException(f"error fetching posts: {response.code()} {response.status_line()}")
 
-        json = response.decoded_content()
-
-        data = dict(decode_json(json))
+        data = dict(response.decoded_json())
 
         if 'results' not in data:
             raise McPostsBWTwitterDataException("error parsing response: " + json)


### PR DESCRIPTION
I'm having trouble building `cliff-annotator` for this branch on my machine for reasons that I thinnnnk relate to `com.thoughtworks.xstream.core.util.Fields`? Stack trace [here](https://gist.github.com/jtotoole/c2a5b2bc1b4d05e94b9b9765edfceb3a).

I'm happy to work on solving this if it's a blocker to merging, but I figured I'd submit the PR for now and let you decide. Thanks again for the feedback!