### PR TITLE
drop cliff_ + nytlabels_annotations tables

### DIFF
--- a/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
+++ b/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
@@ -6,7 +6,7 @@ botocore==1.12.247
 certifi==2019.9.11
 chardet==3.0.4
 docutils==0.15.2
-gast==0.2.2
+gast==0.3.2
 gensim==3.8.1
 google-pasta==0.1.7
 grpcio==1.24.1
@@ -29,7 +29,7 @@ scikit-learn==0.21.3
 scipy==1.3.1
 six==1.12.0
 smart-open==1.8.4
-tensorboard==1.15.0
+tensorboard==1.14.0
 tensorflow==1.15.4
 tensorflow-estimator==1.15.1
 termcolor==1.1.0

--- a/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
+++ b/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
@@ -6,7 +6,7 @@ botocore==1.12.247
 certifi==2019.9.11
 chardet==3.0.4
 docutils==0.15.2
-gast==0.3.2
+gast==0.2.2
 gensim==3.8.1
 google-pasta==0.1.7
 grpcio==1.24.1
@@ -29,7 +29,7 @@ scikit-learn==0.21.3
 scipy==1.3.1
 six==1.12.0
 smart-open==1.8.4
-tensorboard==1.14.0
+tensorboard==1.15.0
 tensorflow==1.15.4
 tensorflow-estimator==1.15.1
 termcolor==1.1.0

--- a/apps/postgresql-server/schema/mediawords.sql
+++ b/apps/postgresql-server/schema/mediawords.sql
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
 DECLARE
     -- Database schema version number (same as a SVN revision number)
     -- Increase it by 1 if you make major database schema changes.
-    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4759;
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4760;
 BEGIN
 
     -- Update / set database schema version
@@ -3592,38 +3592,6 @@ CREATE TRIGGER extractor_results_cache_test_referenced_download_trigger
     FOR EACH ROW
     EXECUTE PROCEDURE test_referenced_download_trigger('downloads_id');
 
-
---
--- CLIFF annotations
---
-CREATE TABLE cliff_annotations (
-    cliff_annotations_id  SERIAL    PRIMARY KEY,
-    object_id             INTEGER   NOT NULL REFERENCES stories (stories_id) ON DELETE CASCADE,
-    raw_data              BYTEA     NOT NULL
-);
-CREATE UNIQUE INDEX cliff_annotations_object_id ON cliff_annotations (object_id);
-
--- Don't (attempt to) compress BLOBs in "raw_data" because they're going to be
--- compressed already
-ALTER TABLE cliff_annotations
-    ALTER COLUMN raw_data SET STORAGE EXTERNAL;
-
-
-
---
--- NYTLabels annotations
---
-CREATE TABLE nytlabels_annotations (
-    nytlabels_annotations_id  SERIAL    PRIMARY KEY,
-    object_id                 INTEGER   NOT NULL REFERENCES stories (stories_id) ON DELETE CASCADE,
-    raw_data                  BYTEA     NOT NULL
-);
-CREATE UNIQUE INDEX nytlabels_annotations_object_id ON nytlabels_annotations (object_id);
-
--- Don't (attempt to) compress BLOBs in "raw_data" because they're going to be
--- compressed already
-ALTER TABLE nytlabels_annotations
-    ALTER COLUMN raw_data SET STORAGE EXTERNAL;
 
 -- keep track of per domain web requests so that we can throttle them using mediawords.util.web.user_agent.throttled.
 -- this is unlogged because we don't care about anything more than about 10 seconds old.  we don't have a primary

--- a/apps/postgresql-server/schema/migrations/mediawords-4759-4760.sql
+++ b/apps/postgresql-server/schema/migrations/mediawords-4759-4760.sql
@@ -1,0 +1,33 @@
+--
+-- This is a Media Cloud PostgreSQL schema difference file (a "diff") between schema
+-- versions 4759 and 4760.
+--
+-- If you are running Media Cloud with a database that was set up with a schema version
+-- 4759, and you would like to upgrade both the Media Cloud and the
+-- database to be at version 4760, import this SQL file:
+--
+--     psql mediacloud < mediawords-4759-4760.sql
+--
+-- You might need to import some additional schema diff files to reach the desired version.
+--
+
+--
+-- 1 of 2. Import the output of 'apgdiff':
+--
+
+SET search_path = public, pg_catalog;
+
+TRUNCATE cliff_annotations;
+DROP TABLE cliff_annotations;
+
+TRUNCATE nytlabels_annotations;
+DROP TABLE nytlabels_annotations;
+
+END;
+$$
+LANGUAGE 'plpgsql';
+
+--
+-- 2 of 2. Reset the database version.
+--
+SELECT set_database_schema_version();


### PR DESCRIPTION
Relates to https://github.com/mediacloud/backend/issues/743

The `postgresql-server` image wouldn't build for me locally due to the following error:

```
psql:/opt/mediacloud/schema/mediawords.sql:1107: NOTICE:  Creating partition "downloads_success_content_00" for download ID 1
2020-12-22 15:35:58 EST [68-1] postgres@mediacloud ERROR:  query has no destination for result data
2020-12-22 15:35:58 EST [68-2] postgres@mediacloud HINT:  If you want to discard the results of a SELECT, use PERFORM instead.
2020-12-22 15:35:58 EST [68-3] postgres@mediacloud CONTEXT:  PL/pgSQL function partition_by_downloads_id_create_partitions(text) line 40 at SQL statement
        SQL statement "SELECT ARRAY(SELECT partition_by_downloads_id_create_partitions(base_table_name))"
        PL/pgSQL function downloads_create_subpartitions(text) line 7 at assignment
2020-12-22 15:35:58 EST [68-4] postgres@mediacloud STATEMENT:  SELECT downloads_success_content_create_partitions();
psql:/opt/mediacloud/schema/mediawords.sql:1107: ERROR:  query has no destination for result data
HINT:  If you want to discard the results of a SELECT, use PERFORM instead.
CONTEXT:  PL/pgSQL function partition_by_downloads_id_create_partitions(text) line 40 at SQL statement
SQL statement "SELECT ARRAY(SELECT partition_by_downloads_id_create_partitions(base_table_name))"
PL/pgSQL function downloads_create_subpartitions(text) line 7 at assignment
The command '/bin/sh -c /opt/mediacloud/bin/initialize_schema.sh' returned a non-zero code: 3
```

^That seeeeeems related to existing production code that I'm assuming works fine—anything to worry about?