### PR TITLE
fix google podcasts crawler + test

### DIFF
--- a/apps/crawler-fetcher/tests/python/test_podcast_resolve_url.py
+++ b/apps/crawler-fetcher/tests/python/test_podcast_resolve_url.py
@@ -37,16 +37,20 @@ def test_get_feed_url_from_google_podcasts_url():
 
     ra_feed_url = 'https://www.residentadvisor.net/xml/podcast.xml'
 
+    # Test with URL pointing to a show's homepage (not invidual episode)
+
     ra_google_url = (
         'https://podcasts.google.com/?feed=aHR0cHM6Ly93d3cucmVzaWRlbnRhZHZpc29yLm5ldC94bWwvcG9kY2FzdC54bWw&'
         'ved=0CAAQ4aUDahcKEwiot6W5hrnnAhUAAAAAHQAAAAAQAQ&hl=lt'
     )
+
     assert _get_feed_url_from_google_podcasts_url(ra_google_url) == ra_feed_url
 
     # Test with URL that point to a specific episode
     ra_google_url = (
-        'https://podcasts.google.com/?feed=aHR0cHM6Ly93d3cucmVzaWRlbnRhZHZpc29yLm5ldC94bWwvcG9kY2FzdC54bWw&'
-        'episode=aHR0cDovL3d3dy5yZXNpZGVudGFkdmlzb3IubmV0L3BvZGNhc3QtZXBpc29kZS5hc3B4P2lkPTcxNA&'
-        'ved=0CAIQkfYCahcKEwjwsNLrmLvnAhUAAAAAHQAAAAAQAQ&hl=lt'
+        'https://podcasts.google.com/feed/aHR0cHM6Ly93d3cucmVzaWRlbnRhZHZpc29yLm5ldC94bWwvcG9kY2FzdC54bWw/episode/'
+        'aHR0cDovL3d3dy5yZXNpZGVudGFkdmlzb3IubmV0L3BvZGNhc3QtZXBpc29kZS5hc3B4P2lkPTc2MA?sa=X'
+        '&ved=0CAUQkfYCahcKEwi487Knw_HtAhUAAAAAHQAAAAAQAQ'
     )
+
     assert _get_feed_url_from_google_podcasts_url(ra_google_url) == ra_feed_url

--- a/apps/crawler-fetcher/tests/python/test_podcast_resolve_url.py
+++ b/apps/crawler-fetcher/tests/python/test_podcast_resolve_url.py
@@ -13,18 +13,17 @@ def test_get_feed_url_from_itunes_podcasts_url():
     assert _get_feed_url_from_itunes_podcasts_url('totally not an URL') == 'totally not an URL'
 
     # Let's just kind of hope RA doesn't change their underlying feed URL
+    ra_feed_url = 'https://ra.co/xml/podcast.xml'
+
     ra_itunes_url = 'https://podcasts.apple.com/lt/podcast/ra-podcast/id129673441'
-    ra_feed_url = 'https://www.residentadvisor.net/xml/podcast.xml'
     assert _get_feed_url_from_itunes_podcasts_url(ra_itunes_url) == ra_feed_url
 
     # Try uppercase host
     ra_itunes_url = 'https://PODCASTS.APPLE.COM/lt/podcast/ra-podcast/id129673441'
-    ra_feed_url = 'https://www.residentadvisor.net/xml/podcast.xml'
     assert _get_feed_url_from_itunes_podcasts_url(ra_itunes_url) == ra_feed_url
 
     # Try old style URL
     ra_itunes_url = 'https://itunes.apple.com/lt/podcast/ra-podcast/id129673441'
-    ra_feed_url = 'https://www.residentadvisor.net/xml/podcast.xml'
     assert _get_feed_url_from_itunes_podcasts_url(ra_itunes_url) == ra_feed_url
 
 
@@ -35,22 +34,21 @@ def test_get_feed_url_from_google_podcasts_url():
     assert _get_feed_url_from_google_podcasts_url('http://www.example.com/') == 'http://www.example.com/'
     assert _get_feed_url_from_google_podcasts_url('totally not an URL') == 'totally not an URL'
 
-    ra_feed_url = 'https://www.residentadvisor.net/xml/podcast.xml'
+    npr_feed_url = 'https://feeds.npr.org/381444908/podcast.xml'
 
     # Test with URL pointing to a show's homepage (not invidual episode)
 
-    ra_google_url = (
-        'https://podcasts.google.com/?feed=aHR0cHM6Ly93d3cucmVzaWRlbnRhZHZpc29yLm5ldC94bWwvcG9kY2FzdC54bWw&'
-        'ved=0CAAQ4aUDahcKEwiot6W5hrnnAhUAAAAAHQAAAAAQAQ&hl=lt'
+    npr_google_show_url = (
+        'https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5ucHIub3JnLzM4MTQ0NDkwOC9wb2RjYXN0LnhtbA?sa=X'
+        '&ved=2ahUKEwjKm6fimbjuAhWMjoQIHUrSCW0Qjs4CKAl6BAgBEH4'
     )
 
-    assert _get_feed_url_from_google_podcasts_url(ra_google_url) == ra_feed_url
+    assert _get_feed_url_from_google_podcasts_url(npr_google_show_url) == npr_feed_url
 
-    # Test with URL that point to a specific episode
-    ra_google_url = (
-        'https://podcasts.google.com/feed/aHR0cHM6Ly93d3cucmVzaWRlbnRhZHZpc29yLm5ldC94bWwvcG9kY2FzdC54bWw/episode/'
-        'aHR0cDovL3d3dy5yZXNpZGVudGFkdmlzb3IubmV0L3BvZGNhc3QtZXBpc29kZS5hc3B4P2lkPTc2MA?sa=X'
-        '&ved=0CAUQkfYCahcKEwi487Knw_HtAhUAAAAAHQAAAAAQAQ'
+    # Test with URL that points to a specific episode
+    npr_google_ep_url = (
+        'https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5ucHIub3JnLzM4MTQ0NDkwOC9wb2RjYXN0LnhtbA/episode/'
+        'MjA5MmZjM2ItYmMwZi00NGFiLWFlNDktM2I3YmFhMjA4ODVi?sa=X&ved=0CAUQkfYCahcKEwjg4s3umbjuAhUAAAAAHQAAAAAQAQ'
     )
 
-    assert _get_feed_url_from_google_podcasts_url(ra_google_url) == ra_feed_url
+    assert _get_feed_url_from_google_podcasts_url(npr_google_ep_url) == npr_feed_url

--- a/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
+++ b/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
@@ -6,7 +6,7 @@ botocore==1.12.247
 certifi==2019.9.11
 chardet==3.0.4
 docutils==0.15.2
-gast==0.2.2
+gast==0.3.2
 gensim==3.8.1
 google-pasta==0.1.7
 grpcio==1.24.1
@@ -29,7 +29,7 @@ scikit-learn==0.21.3
 scipy==1.3.1
 six==1.12.0
 smart-open==1.8.4
-tensorboard==1.15.0
+tensorboard==1.14.0
 tensorflow==1.15.4
 tensorflow-estimator==1.15.1
 termcolor==1.1.0

--- a/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
+++ b/apps/nytlabels-annotator/src/crappy-predict-news-labels/requirements.txt
@@ -6,7 +6,7 @@ botocore==1.12.247
 certifi==2019.9.11
 chardet==3.0.4
 docutils==0.15.2
-gast==0.3.2
+gast==0.2.2
 gensim==3.8.1
 google-pasta==0.1.7
 grpcio==1.24.1
@@ -29,7 +29,7 @@ scikit-learn==0.21.3
 scipy==1.3.1
 six==1.12.0
 smart-open==1.8.4
-tensorboard==1.14.0
+tensorboard==1.15.0
 tensorflow==1.15.4
 tensorflow-estimator==1.15.1
 termcolor==1.1.0


### PR DESCRIPTION
This test [has been failing](https://github.com/mediacloud/backend/pull/750/checks?check_run_id=1596958198) because the `data-feed="(https?://.+?)` regex no longer works on Google Podcasts show pages if you aren't logged into Google when you fetch the page, and no longer works at all on individual episodes. I tested the new regex patterns with 6 different shows + episode pages, and it works consistently across those. 