### PR TITLE
In /api/v2/stories/cliff, /api/v2/stories/nytlabels, call underlying services directly instead of reading annotations from disk

### DIFF
--- a/apps/extract-and-vector/src/python/extract_and_vector/dbi/stories/process.py
+++ b/apps/extract-and-vector/src/python/extract_and_vector/dbi/stories/process.py
@@ -33,18 +33,6 @@ def process_extracted_story(db: DatabaseHandler, story: dict, extractor_args: Py
     else:
         log.debug("Won't add {} to CLIFF annotation queue because it's not annotatable with CLIFF".format(stories_id))
 
-        if story_is_english_and_has_sentences(db=db, stories_id=stories_id):
-            # If CLIFF annotator is disabled, pass the story to NYTLabels annotator which, if run, will mark the story
-            # as processed
-            log.debug("Adding story {} to NYTLabels annotation queue...".format(stories_id))
-            JobBroker(queue_name='MediaWords::Job::NYTLabels::FetchAnnotation').add_to_queue(stories_id=stories_id)
-
-        else:
-            log.debug("Won't add {} to NYTLabels annotation queue because it's not annotatable with NYTLabels".format(
-                stories_id
-            ))
-
-            # If neither of the annotators are enabled, mark the story as processed ourselves
-            log.debug("Marking the story as processed...")
-            if not mark_as_processed(db=db, stories_id=stories_id):
-                raise McProcessExtractedStoryException("Unable to mark story ID {} as processed".format(stories_id))
+        log.debug("Marking the story as processed...")
+        if not mark_as_processed(db=db, stories_id=stories_id):
+            raise McProcessExtractedStoryException("Unable to mark story ID {} as processed".format(stories_id))

--- a/apps/webapp-api/docker-compose.tests.yml
+++ b/apps/webapp-api/docker-compose.tests.yml
@@ -20,6 +20,8 @@ services:
               source: ./../common/src/
               target: /opt/mediacloud/src/common/
         depends_on:
+            - cliff-annotator
+            - nytlabels-annotator
             - postgresql-pgbouncer
             - solr-shard-01
             - rabbitmq-server
@@ -29,6 +31,16 @@ services:
             - topics-snapshot
             # Multiple tests import Solr data
             - import-solr-data-for-testing
+
+    cliff-annotator:
+        image: gcr.io/mcback/cliff-annotator:latest
+        init: true
+        stop_signal: SIGKILL
+
+    nytlabels-annotator:
+        image: gcr.io/mcback/nytlabels-annotator:latest
+        init: true
+        stop_signal: SIGKILL
 
     postgresql-pgbouncer:
         image: gcr.io/mcback/postgresql-pgbouncer:latest

--- a/apps/webapp-api/src/perl/MediaWords/Controller/Api/V2/Stories.pm
+++ b/apps/webapp-api/src/perl/MediaWords/Controller/Api/V2/Stories.pm
@@ -16,6 +16,8 @@ use MediaWords::Annotator::Store;
 use MediaWords::DBI::Stories;
 use MediaWords::Solr;
 use MediaWords::Util::ParseJSON;
+use MediaWords::Util::Web::UserAgent;
+use MediaWords::Util::Web::UserAgent::Request;
 
 =head1 NAME
 
@@ -87,6 +89,117 @@ sub put_tags_PUT
     return;
 }
 
+sub _cliff_annotator_request($)
+{
+    my $text = shift;
+
+    my $url = 'http://cliff-annotator:8080/cliff/parse/text';
+    my $request = MediaWords::Util::Web::UserAgent::Request->new( 'POST', $url );
+    $request->set_content_type( 'application/x-www-form-urlencoded; charset=utf-8' );
+    $request->set_content( {'q' => $text } );
+
+    return $request;
+}
+
+sub _nytlabels_annotator_request($)
+{
+    my $text = shift;
+
+    my $url = 'http://nytlabels-annotator:8080/predict.json';
+    my $request = MediaWords::Util::Web::UserAgent::Request->new( 'POST', $url );
+    $request->set_content_type( 'application/json; charset=utf-8' );
+    $request->set_content( MediaWords::Util::ParseJSON::encode_json( {'text' => $text}) );
+
+    return $request;
+}
+
+# FIXME once the API gets rewritten to Python (any day now!), make it reuse
+# same code that calls annotator from extractor instead of this awful hack
+sub _annotate_story_ids($$$$)
+{
+    my ( $db, $stories_ids, $results_key, $request_generator_subref ) = @_;
+
+    unless ( ref( $request_generator_subref ) eq ref( sub {} )) {
+        LOGDIE "Request generator is not a subref";
+    }
+
+    $stories_ids = [ $stories_ids ] unless ( ref( $stories_ids ) );
+
+    DEBUG "Annotating " . scalar(@{ $stories_ids }) . " stories...";
+    my $json_list = {};
+    for my $stories_id ( @{ $stories_ids } )
+    {
+        $stories_id = int( $stories_id );
+
+        next if ( $json_list->{ $stories_id } );
+
+        DEBUG "Fetching story $stories_id...";
+        my $story = $db->find_by_id( 'stories', $stories_id );
+        unless ( $story ) {
+            $json_list->{ $stories_id } = 'story does not exist';
+            next;
+        }
+
+        unless ( $story->{ language } eq 'en' or ( ! defined $story->language )) {
+            $json_list->{ $stories_id } = 'story is not in English';
+            next;
+        }
+
+        DEBUG "Fetching concatenated sentences for story $stories_id...";
+        my ( $full_text ) = $db->query( <<SQL,
+            SELECT string_agg(sentence, ' ' ORDER BY sentence_number)
+            FROM story_sentences
+            WHERE stories_id = ?
+SQL
+            $story->{ stories_id }
+        )->flat();
+        unless ( $full_text ) {
+            $json_list->{ $stories_id } = 'story does not have any sentences';
+            next;
+        }
+
+        DEBUG "Annotating story $stories_id...";
+        my $request = $request_generator_subref->( $full_text );
+
+        my $ua = MediaWords::Util::Web::UserAgent->new();
+        $ua->set_timing( [1, 2, 4, 8] );
+        $ua->set_timeout( 60 * 10 );
+        $ua->set_max_size( undef );
+
+        my $response = $ua->request( $request );
+
+        unless ( $response->is_success() ) {
+            ERROR "Fetching annotation for story $stories_id failed: " . $response->decoded_content();
+            $json_list->{ $stories_id } = 'annotating failed';
+            next;
+        }
+
+        my $annotation = MediaWords::Util::ParseJSON::decode_json( $response->decoded_content() );
+
+        $json_list->{ $stories_id } = $annotation;
+    }
+
+    my $json_items = [];
+
+    # Iterate over original list of story ID parameters to preserve order
+    for my $stories_id ( @{ $stories_ids } )
+    {
+        my $json_item = {
+            stories_id   => $stories_id + 0,
+            $results_key => $json_list->{ $stories_id },
+        };
+        push( @{ $json_items }, $json_item );
+    }
+
+    Readonly my $json_pretty => 1;
+    my $json = MediaWords::Util::ParseJSON::encode_json( $json_items, $json_pretty );
+
+    # Catalyst expects bytes
+    $json = encode_utf8( $json );
+
+    return $json;
+}
+
 sub cliff : Local
 {
     my ( $self, $c ) = @_;
@@ -99,49 +212,7 @@ sub cliff : Local
         die "One or more 'stories_id' is required.";
     }
 
-    $stories_ids = [ $stories_ids ] unless ( ref( $stories_ids ) );
-
-    my $json_list = {};
-    for my $stories_id ( @{ $stories_ids } )
-    {
-        $stories_id = int( $stories_id );
-
-        next if ( $json_list->{ $stories_id } );
-
-        my $annotation;
-
-        my $story = $db->find_by_id( 'stories', $stories_id );
-        if ( !$story )
-        {
-            # mostly useful for testing this end point without triggering a fatal error because CLIFF is not enabled
-            $annotation = 'story does not exist';
-        }
-        else
-        {
-            my $cliff_store = MediaWords::Annotator::Store->new('cliff_annotations');
-            eval { $annotation = $cliff_store->fetch_annotation_for_story( $db, $stories_id ); };
-            $annotation ||= 'story is not annotated';
-        }
-
-        $json_list->{ $stories_id } = $annotation;
-
-    }
-
-    my $json_items = [];
-    for my $stories_id ( keys( %{ $json_list } ) )
-    {
-        my $json_item = {
-            stories_id => $stories_id + 0,
-            cliff      => $json_list->{ $stories_id },
-        };
-        push( @{ $json_items }, $json_item );
-    }
-
-    Readonly my $json_pretty => 1;
-    my $json = MediaWords::Util::ParseJSON::encode_json( $json_items, $json_pretty );
-
-    # Catalyst expects bytes
-    $json = encode_utf8( $json );
+    my $json = _annotate_story_ids( $db, $stories_ids, 'cliff', \&_cliff_annotator_request );
 
     $c->response->content_type( 'application/json; charset=UTF-8' );
     $c->response->content_length( bytes::length( $json ) );
@@ -160,49 +231,7 @@ sub nytlabels : Local
         die "One or more 'stories_id' is required.";
     }
 
-    $stories_ids = [ $stories_ids ] unless ( ref( $stories_ids ) );
-
-    my $json_list = {};
-    for my $stories_id ( @{ $stories_ids } )
-    {
-        $stories_id = int( $stories_id );
-
-        next if ( $json_list->{ $stories_id } );
-
-        my $annotation;
-
-        my $story = $db->find_by_id( 'stories', $stories_id );
-        if ( !$story )
-        {
-            # mostly useful for testing this end point without triggering a fatal error because NYTLabels is not enabled
-            $annotation = 'story does not exist';
-        }
-        else
-        {
-            my $nytlabels_store = MediaWords::Annotator::Store->new('nytlabels_annotations');
-            eval { $annotation = $nytlabels_store->fetch_annotation_for_story( $db, $stories_id ) };
-            $annotation ||= 'story is not annotated';
-        }
-
-        $json_list->{ $stories_id } = $annotation;
-
-    }
-
-    my $json_items = [];
-    for my $stories_id ( keys( %{ $json_list } ) )
-    {
-        my $json_item = {
-            stories_id => $stories_id + 0,
-            nytlabels  => $json_list->{ $stories_id },
-        };
-        push( @{ $json_items }, $json_item );
-    }
-
-    Readonly my $json_pretty => 1;
-    my $json = MediaWords::Util::ParseJSON::encode_json( $json_items, $json_pretty );
-
-    # Catalyst expects bytes
-    $json = encode_utf8( $json );
+    my $json = _annotate_story_ids( $db, $stories_ids, 'nytlabels', \&_nytlabels_annotator_request );
 
     $c->response->content_type( 'application/json; charset=UTF-8' );
     $c->response->content_length( bytes::length( $json ) );

--- a/apps/webapp-api/src/perl/MediaWords/Test/API.pm
+++ b/apps/webapp-api/src/perl/MediaWords/Test/API.pm
@@ -56,19 +56,6 @@ sub get_test_api_key()
     return $_test_api_key;
 }
 
-# test that all fields with purely number responses return JSON numbers
-sub __validate_number_fields($$)
-{
-    my ( $label, $json ) = @_;
-
-    while ( $json =~ /("[^"]+"\s*:\s*"[\d]+")/g )
-    {
-        ok( 0, "$label number field has been stringified: $1" );
-        WARN( "json: " . substr( $json, 0, 2048 ) );
-        die();
-    }
-}
-
 #  test that we got a valid response,
 # that the response is valid json, and that the JSON response is not an error response.  Return
 # the decoded json.  If $expect_error is true, test for expected error response.
@@ -89,8 +76,6 @@ sub test_request_response($$;$)
     my $data = eval { MediaWords::Util::ParseJSON::decode_json( $response->decoded_content ) };
 
     ok( $data, "decoded JSON for $label (json error: $@)" );
-
-    __validate_number_fields( $label, $response->decoded_content );
 
     if ( $expect_error )
     {

--- a/apps/webapp-api/tests/perl/MediaWords/Controller/Api/V2/Stories.t
+++ b/apps/webapp-api/tests/perl/MediaWords/Controller/Api/V2/Stories.t
@@ -36,20 +36,31 @@ sub test_stories_cliff($)
 {
     my ( $db ) = @_;
 
-    # TODO add infrastructure to actually generate CLIFF and test it
-
     my $label = "stories/cliff";
 
-    # pick a stories_id that does not exist so that we make the end point just tell us that the
-    # end point does not exist instead of triggering a fatal error
-    my $stories_id = -1;
+    # 1. Test what happens with both story ID that exists and the one that
+    #    doesn't;
+    # 2. Pass arguments in an awkward order to make sure the order is preserved
+    #    in results.
+    my $existent_stories_id = 1;
+    my $nonexistent_stories_id = -1;
+    my $stories_ids = [ $existent_stories_id, $nonexistent_stories_id ];
 
-    my $r = MediaWords::Test::API::test_get( '/api/v2/stories/cliff', { stories_id => $stories_id } );
+    my $r = MediaWords::Test::API::test_get( '/api/v2/stories/cliff', { stories_id => $stories_ids } );
 
-    is( scalar( @{ $r } ),         1,           "$label num stories returned" );
-    is( $r->[ 0 ]->{ stories_id }, $stories_id, "$label stories_id" );
+    is( scalar( @{ $r } ),         scalar( @{ $stories_ids } ), "$label num stories returned" );
+
+    is( $r->[ 0 ]->{ stories_id }, $existent_stories_id, "$label existent_stories_id" );
     MediaWords::Test::Types::is_integer( $r->[ 0 ]->{ stories_id }, "$label stories_id is_integer" );
-    is( $r->[ 0 ]->{ cliff }, "story does not exist", "$label does not exist message" );
+    ok( $r->[ 0 ]->{ cliff }, "$label cliff" );
+    ok( $r->[ 0 ]->{ cliff }->{ results }, "$label cliff->results" );
+    ok( $r->[ 0 ]->{ cliff }->{ results }->{ organizations }, "$label cliff->results->organizations" );
+    ok( $r->[ 0 ]->{ cliff }->{ results }->{ places }, "$label cliff->results->places" );
+    ok( $r->[ 0 ]->{ cliff }->{ results }->{ people }, "$label cliff->results->people" );
+
+    is( $r->[ 1 ]->{ stories_id }, $nonexistent_stories_id, "$label nonexistent_stories_id" );
+    MediaWords::Test::Types::is_integer( $r->[ 1 ]->{ stories_id }, "$label stories_id is_integer" );
+    is( $r->[ 1 ]->{ cliff }, "story does not exist", "$label does not exist message" );
 }
 
 sub test_stories_is_syndicated_ap($)
@@ -70,20 +81,32 @@ sub test_stories_nytlabels($)
 {
     my ( $db ) = @_;
 
-    # TODO add infrastructure to actually generate NYTLabels and test it
-
     my $label = "stories/nytlabels";
 
-    # pick a stories_id that does not exist so that we make the end point just tell us that the
-    # end point does not exist instead of triggering a fatal error
-    my $stories_id = -1;
+    # 1. Test what happens with both story ID that exists and the one that
+    #    doesn't;
+    # 2. Pass arguments in an awkward order to make sure the order is preserved
+    #    in results.
+    my $existent_stories_id = 1;
+    my $nonexistent_stories_id = -1;
+    my $stories_ids = [ $existent_stories_id, $nonexistent_stories_id ];
 
-    my $r = MediaWords::Test::API::test_get( '/api/v2/stories/nytlabels', { stories_id => $stories_id } );
+    my $r = MediaWords::Test::API::test_get( '/api/v2/stories/nytlabels', { stories_id => $stories_ids } );
 
-    is( scalar( @{ $r } ),         1,           "$label num stories returned" );
-    is( $r->[ 0 ]->{ stories_id }, $stories_id, "$label stories_id" );
+    is( scalar( @{ $r } ),         scalar( @{ $stories_ids } ), "$label num stories returned" );
+
+    is( $r->[ 0 ]->{ stories_id }, $existent_stories_id, "$label existent_stories_id" );
     MediaWords::Test::Types::is_integer( $r->[ 0 ]->{ stories_id }, "$label stories_id is_integer" );
-    is( $r->[ 0 ]->{ nytlabels }, "story does not exist", "$label does not exist message" );
+    ok( $r->[ 0 ]->{ nytlabels }, "$label nytlabels" );
+    ok( $r->[ 0 ]->{ nytlabels }->{ allDescriptors }, "$label nytlabels->allDescriptors" );
+    ok( $r->[ 0 ]->{ nytlabels }->{ descriptors600 }, "$label nytlabels->descriptors600" );
+    ok( $r->[ 0 ]->{ nytlabels }->{ descriptorsAndTaxonomies }, "$label nytlabels->descriptorsAndTaxonomies" );
+    ok( $r->[ 0 ]->{ nytlabels }->{ descriptors3000 }, "$label nytlabels->descriptors3000" );
+    ok( $r->[ 0 ]->{ nytlabels }->{ taxonomies }, "$label nytlabels->taxonomies" );
+
+    is( $r->[ 1 ]->{ stories_id }, $nonexistent_stories_id, "$label nonexistent_stories_id" );
+    MediaWords::Test::Types::is_integer( $r->[ 1 ]->{ stories_id }, "$label stories_id is_integer" );
+    is( $r->[ 1 ]->{ nytlabels }, "story does not exist", "$label does not exist message" );
 }
 
 sub test_stories_list($)


### PR DESCRIPTION
References #743.

Unblocks https://github.com/mediacloud/backend/pull/745, https://github.com/mediacloud/backend/pull/751.

Some other minor changes:

* When both API calls can't / refuse to annotate story's text, returned error messages are a little bit more specific.
* Now that `nytlabels-annotator` is rather "right" (takes up only 500 or so MB of RAM to run), I've added it to `webapp-api`'s `docker-compose.tests.yml` and made the tests actually use the underlying annotator.

The not-so-nice part is that `_annotate_story_ids()` below is a Perl implementation of James's Python subroutine that does the same stuff, but to get rid of it we'll have to rewrite the webapp to Python first.
