### PR TITLE
Update postfix headers

### DIFF
--- a/apps/common/docker-compose.tests.yml
+++ b/apps/common/docker-compose.tests.yml
@@ -18,7 +18,7 @@ services:
             # emails are more likely to be marked spam if we don't have such a header, so
             # we make the email subject "Delete account and unsubscribe" in 
             # mediawords/util/config/common.py
-            MC_UNSUBSCRIBE_MAILTO_LINK: "support@example.com"
+            MC_EMAIL_UNSUBSCRIBE: "support@example.com"
         volumes:
             - type: bind
               source: ./src/

--- a/apps/common/docker-compose.tests.yml
+++ b/apps/common/docker-compose.tests.yml
@@ -13,6 +13,12 @@ services:
             MC_DOWNLOADS_AMAZON_S3_DIRECTORY_NAME: "${MC_DOWNLOADS_AMAZON_S3_DIRECTORY_NAME}"
             MC_PUBLIC_STORE_TYPE: "postgresql"
             MC_PUBLIC_STORE_SALT: "foo"
+            # Email address to point to in List-Unsubscribe email header.
+            # Technically we don't have a straightforward "unsubscribe" endpoint, but our 
+            # emails are more likely to be marked spam if we don't have such a header, so
+            # we make the email subject "Delete account and unsubscribe" in 
+            # mediawords/util/config/common.py
+            MC_UNSUBSCRIBE_MAILTO_LINK: "support@example.com"
         volumes:
             - type: bind
               source: ./src/

--- a/apps/common/src/python/mediawords/util/config/common.py
+++ b/apps/common/src/python/mediawords/util/config/common.py
@@ -155,6 +155,14 @@ class SMTPConfig(object):
         """Password."""
         return ''
 
+    @staticmethod
+    def unsubscribe_address() -> str:
+        """Mailto link for email to which unsubscribe/account deletion requests should be sent"""
+        address = env_value('MC_UNSUBSCRIBE_MAILTO_LINK', required=False, allow_empty_string=True)
+        if address is None or '@' not in address:
+            address = 'support@example.com'
+        return f'mailto:{address}?subject=Delete%20account%20and%20unsubscribe'
+
 
 class DownloadStorageConfig(object):
     """Download storage configuration."""

--- a/apps/common/src/python/mediawords/util/config/common.py
+++ b/apps/common/src/python/mediawords/util/config/common.py
@@ -158,10 +158,11 @@ class SMTPConfig(object):
     @staticmethod
     def unsubscribe_address() -> str:
         """Mailto link for email to which unsubscribe/account deletion requests should be sent"""
-        address = env_value('MC_UNSUBSCRIBE_MAILTO_LINK', required=False, allow_empty_string=True)
+        address = env_value('MC_EMAIL_UNSUBSCRIBE', required=False, allow_empty_string=True)
         if address is None or '@' not in address:
             address = 'support@example.com'
-        return f'mailto:{address}?subject=Delete%20account%20and%20unsubscribe'
+        return address
+        # return f'mailto:{address}?subject=Delete%20account%20and%20unsubscribe'
 
 
 class DownloadStorageConfig(object):

--- a/apps/common/src/python/mediawords/util/config/common.py
+++ b/apps/common/src/python/mediawords/util/config/common.py
@@ -157,12 +157,11 @@ class SMTPConfig(object):
 
     @staticmethod
     def unsubscribe_address() -> str:
-        """Mailto link for email to which unsubscribe/account deletion requests should be sent"""
+        """Email to which unsubscribe/account deletion requests should be sent"""
         address = env_value('MC_EMAIL_UNSUBSCRIBE', required=False, allow_empty_string=True)
         if address is None or '@' not in address:
             address = 'support@example.com'
         return address
-        # return f'mailto:{address}?subject=Delete%20account%20and%20unsubscribe'
 
 
 class DownloadStorageConfig(object):

--- a/apps/common/src/python/mediawords/util/mail.py
+++ b/apps/common/src/python/mediawords/util/mail.py
@@ -117,11 +117,14 @@ def send_email(message: Message) -> bool:
             message_part = MIMEText(message.text_body, 'plain', 'utf-8')
             mime_message.attach(message_part)
 
+        mime_message.add_header('List-Unsubscribe',
+                                'mailto:support@mediacloud.org?subject=Delete%20account%20and%20unsubscribe')
+
         # HTML gets attached last, thus making it a preferred part as per RFC
         if message.html_body:
             message_part = MIMEText(message.html_body, 'html', 'utf-8')
             mime_message.attach(message_part)
-
+        print(mime_message)
         if test_mode_is_enabled():
             log.info("Test mode is enabled, not actually sending any email.")
             log.debug("Omitted email:\n\n%s" % mime_message.as_string())
@@ -136,6 +139,7 @@ def send_email(message: Message) -> bool:
 
             # Send message
             refused_recipients = smtp.sendmail(mime_message['From'], mime_message['To'], mime_message.as_string())
+
             if len(refused_recipients):
                 log.warning("Unable to send email to the following recipients: %s" % str(refused_recipients))
 
@@ -160,4 +164,5 @@ def send_text_email(to: str, subject: str, body: str) -> bool:
     body = decode_object_from_bytes_if_needed(body)
 
     message = Message(to=to, subject=subject, text_body=body)
+
     return send_email(message)

--- a/apps/common/src/python/mediawords/util/mail.py
+++ b/apps/common/src/python/mediawords/util/mail.py
@@ -117,7 +117,11 @@ def send_email(message: Message) -> bool:
             message_part = MIMEText(message.text_body, 'plain', 'utf-8')
             mime_message.attach(message_part)
 
-        mime_message.add_header('List-Unsubscribe', CommonConfig.smtp().unsubscribe_address())
+        unsubscribe_address = CommonConfig.smtp().unsubscribe_address()
+        
+        mime_message.add_header(
+            'List-Unsubscribe', 
+             f'mailto:{unsubscribe_address}?subject=Delete%20account%20and%20unsubscribe')
 
         # HTML gets attached last, thus making it a preferred part as per RFC
         if message.html_body:

--- a/apps/common/src/python/mediawords/util/mail.py
+++ b/apps/common/src/python/mediawords/util/mail.py
@@ -117,8 +117,7 @@ def send_email(message: Message) -> bool:
             message_part = MIMEText(message.text_body, 'plain', 'utf-8')
             mime_message.attach(message_part)
 
-        mime_message.add_header('List-Unsubscribe',
-                                'mailto:support@mediacloud.org?subject=Delete%20account%20and%20unsubscribe')
+        mime_message.add_header('List-Unsubscribe', CommonConfig.smtp().unsubscribe_address())
 
         # HTML gets attached last, thus making it a preferred part as per RFC
         if message.html_body:

--- a/apps/common/src/python/mediawords/util/mail.py
+++ b/apps/common/src/python/mediawords/util/mail.py
@@ -124,7 +124,7 @@ def send_email(message: Message) -> bool:
         if message.html_body:
             message_part = MIMEText(message.html_body, 'html', 'utf-8')
             mime_message.attach(message_part)
-        
+
         if test_mode_is_enabled():
             log.info("Test mode is enabled, not actually sending any email.")
             log.debug("Omitted email:\n\n%s" % mime_message.as_string())
@@ -139,7 +139,6 @@ def send_email(message: Message) -> bool:
 
             # Send message
             refused_recipients = smtp.sendmail(mime_message['From'], mime_message['To'], mime_message.as_string())
-
             if len(refused_recipients):
                 log.warning("Unable to send email to the following recipients: %s" % str(refused_recipients))
 
@@ -164,5 +163,4 @@ def send_text_email(to: str, subject: str, body: str) -> bool:
     body = decode_object_from_bytes_if_needed(body)
 
     message = Message(to=to, subject=subject, text_body=body)
-
     return send_email(message)

--- a/apps/common/src/python/mediawords/util/mail.py
+++ b/apps/common/src/python/mediawords/util/mail.py
@@ -124,7 +124,7 @@ def send_email(message: Message) -> bool:
         if message.html_body:
             message_part = MIMEText(message.html_body, 'html', 'utf-8')
             mime_message.attach(message_part)
-        print(mime_message)
+        
         if test_mode_is_enabled():
             log.info("Test mode is enabled, not actually sending any email.")
             log.debug("Omitted email:\n\n%s" % mime_message.as_string())

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -74,6 +74,14 @@ x-common-configuration: &common-configuration
     # "From:" email address when sending emails
     MC_EMAIL_FROM_ADDRESS: "info@mediacloud.org"
 
+    # Email address to point to in List-Unsubscribe email header.
+    # Technically we don't have a straightforward "unsubscribe" endpoint, but our 
+    # emails are more likely to be marked spam if we don't have such a header, so
+    # we make the email subject "Delete account and unsubscribe" in 
+    # mediawords/util/config/common.py
+    # example value = support@example.com 
+    MC_UNSUBSCRIBE_MAILTO_LINK: "support@example.com"
+
     # Fail all HTTP requests that match the following pattern, e.g.
     # "^https?://[^/]*some-website.com"
     MC_USERAGENT_BLACKLIST_URL_PATTERN: ""

--- a/apps/docker-compose.dist.yml
+++ b/apps/docker-compose.dist.yml
@@ -80,7 +80,7 @@ x-common-configuration: &common-configuration
     # we make the email subject "Delete account and unsubscribe" in 
     # mediawords/util/config/common.py
     # example value = support@example.com 
-    MC_UNSUBSCRIBE_MAILTO_LINK: "support@example.com"
+    MC_EMAIL_UNSUBSCRIBE: "support@example.com"
 
     # Fail all HTTP requests that match the following pattern, e.g.
     # "^https?://[^/]*some-website.com"

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -57,6 +57,10 @@ RUN \
     postconf -e smtp_tls_security_level=may && \
     postconf -e smtpd_tls_security_level=none && \
     #
+    # Make sure default headers (e.g. Message-Id, date) are present
+    postconf -e always_add_missing_headers=yes && \
+    postconf -e local_header_rewrite_clients=permit_inet_interfaces && \
+    #
     # Disable chroot on all services as it doesn't play well with a mounted
     # volume, e.g. "smtpd" is unable to access libnss after a chroot and thus
     # resolve OpenDKIM container.

--- a/apps/mail-postfix-server/Dockerfile
+++ b/apps/mail-postfix-server/Dockerfile
@@ -50,7 +50,6 @@ RUN \
     #
     # Filter out "Received:" and some other headers
     postconf -e header_checks=regexp:/etc/postfix/header_checks && \
-    postconf -e mime_header_checks=regexp:/etc/postfix/header_checks && \
     postconf -e smtp_header_checks=regexp:/etc/postfix/header_checks && \
     #
     # Don't require TLS as local clients are trusted

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -20,6 +20,10 @@ services:
         image: gcr.io/mcback/common:latest
         init: true
         stop_signal: SIGKILL
+        volumes:
+            - type: bind
+              source: ./../common/src/
+              target: /opt/mediacloud/src/common/
         depends_on:
             - mail-postfix-server-actual
 

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -10,7 +10,11 @@ services:
     #     - (new terminal window) host$ docker ps
     #     - find container with name ending in 'mail-postfix-server-actual_1'
     #     - host$ docker exec -it some_string_mail-postfix-server-actual_1 bash
-    #     - container$ sendmail "your@email.com"
+    #     - mail-postfix-server-actual_1_container$ ./postfix.sh
+    #     - open new terminal window on your host machine
+    #     - host$ docker exec -it some_string_mail-postfix-server-actual_1 bash
+    #     - follow instructions at URL below to create a test mail.txt file and send to your email address from the container
+    #     https://clients.javapipe.com/knowledgebase/132/How-to-Test-Sendmail-From-Command-Line-on-Linux.html
     #
     mail-postfix-server:
         image: gcr.io/mcback/common:latest

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -4,18 +4,28 @@ services:
 
     # Service to use for testing the mail service
     #
-    # Usage:
+    # Steps to test:
     #
-    #     - host$ ./dev/run.py mail-postfix-server bash
-    #     - (new terminal window) host$ docker ps
-    #     - find container with name ending in 'mail-postfix-server-actual_1'
-    #     - host$ docker exec -it some_string_mail-postfix-server-actual_1 bash
-    #     - mail-postfix-server-actual_1_container$ ./postfix.sh
-    #     - open new terminal window on your host machine
-    #     - host$ docker exec -it some_string_mail-postfix-server-actual_1 bash
-    #     - follow instructions at URL below to create a test mail.txt file and send to your email address from the container
+    #     1) host$ ./dev/run.py mail-postfix-server bash
+    #     2) (new terminal window) host$ docker ps
+    #     3) find container with name ending in 'mail-postfix-server-actual_1'
+    #     4) host$ docker exec -it some_string_mail-postfix-server-actual_1 bash
+    #     5) container$ ./postfix.sh
+    #     6) open new terminal window on your host machine
+    #     7) host$ docker exec -it some_string_mail-postfix-server-actual_1 bash
+    #     8) follow instructions at URL below to create a test mail.txt file and send to your email address from the container
     #     https://clients.javapipe.com/knowledgebase/132/How-to-Test-Sendmail-From-Command-Line-on-Linux.html
     #
+    #     Alternatively, if you want to test via the send_email() method (https://github.com/mediacloud/backend/blob/master/apps/common/src/python/mediawords/util/mail.py#L73),
+    #     or test changes to said method, to you can disregard steps 7-8 above and instead:
+    #     7) host$ docker ps
+    #     8) Find mail-postfix-server container ID
+    #     9) host$ docker exec -it some_string_mail-postfix-server
+    #     10) $container python3
+    #     11) >> from mediawords.util.mail import *
+    #     12) >> test_message = Message(to='your@email.com', subject='test postfix', text_body=None, html_body='<p>hi</p>')
+    #     13) >> send_email(test_message)
+    #    
     mail-postfix-server:
         image: gcr.io/mcback/common:latest
         init: true

--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -6,8 +6,11 @@ services:
     #
     # Usage:
     #
-    #     host$ ./dev/run.py mail-postfix-server bash
-    #     container$ sendmail "your@email.com"
+    #     - host$ ./dev/run.py mail-postfix-server bash
+    #     - (new terminal window) host$ docker ps
+    #     - find container with name ending in 'mail-postfix-server-actual_1'
+    #     - host$ docker exec -it some_string_mail-postfix-server-actual_1 bash
+    #     - container$ sendmail "your@email.com"
     #
     mail-postfix-server:
         image: gcr.io/mcback/common:latest
@@ -21,7 +24,7 @@ services:
         image: gcr.io/mcback/mail-postfix-server:latest
         init: true
         stop_signal: SIGKILL
-        # "docker exec" into a container and run Postfix manually (/postfix.sh):
+        # "docker exec" into a container and run Postfix manually (./postfix.sh):
         command: sleep infinity
         # To be able to set /proc/sys/kernel/yama/ptrace_scope:
         privileged: true

--- a/apps/mail-postfix-server/header_checks
+++ b/apps/mail-postfix-server/header_checks
@@ -2,4 +2,3 @@
 /^X-Originating-IP:/    IGNORE
 /^X-Mailer:/            IGNORE
 /^User-Agent:/          IGNORE
-/^Content-Transfer-Encoding:/i PREPEND List-Unsubscribe: mailto:support@mediacloud.org?subject=Delete%20account%20and%20unsubscribe

--- a/apps/mail-postfix-server/header_checks
+++ b/apps/mail-postfix-server/header_checks
@@ -1,5 +1,5 @@
 /^Received:.*with ESMTP /         IGNORE
 /^X-Originating-IP:/    IGNORE
 /^X-Mailer:/            IGNORE
-/^Mime-Version:/        IGNORE
 /^User-Agent:/          IGNORE
+/^Content-Transfer-Encoding:/i PREPEND List-Unsubscribe: mailto:support@mediacloud.org?subject=delete%20account%20and%20unsubscribe

--- a/apps/mail-postfix-server/header_checks
+++ b/apps/mail-postfix-server/header_checks
@@ -2,4 +2,4 @@
 /^X-Originating-IP:/    IGNORE
 /^X-Mailer:/            IGNORE
 /^User-Agent:/          IGNORE
-/^Content-Transfer-Encoding:/i PREPEND List-Unsubscribe: mailto:support@mediacloud.org?subject=delete%20account%20and%20unsubscribe
+/^Content-Transfer-Encoding:/i PREPEND List-Unsubscribe: mailto:support@mediacloud.org?subject=Delete%20account%20and%20unsubscribe

--- a/apps/topics-map/Dockerfile
+++ b/apps/topics-map/Dockerfile
@@ -6,7 +6,7 @@ FROM gcr.io/mcback/common:latest
 
 # Install Java
 RUN \ 
-    apt-get update && \ 
+    apt-get -y update && \ 
     apt-get -y --no-install-recommends install openjdk-8-jre-headless && \
     true
 

--- a/apps/topics-map/Dockerfile
+++ b/apps/topics-map/Dockerfile
@@ -5,7 +5,10 @@
 FROM gcr.io/mcback/common:latest
 
 # Install Java
-RUN apt-get -y --no-install-recommends install openjdk-8-jre-headless
+RUN \ 
+    apt-get update && \ 
+    apt-get -y --no-install-recommends install openjdk-8-jre-headless && \
+    true
 
 # Install fa2l Java libs
 RUN \


### PR DESCRIPTION
`Message-Id` + `Date` are now working in my testing. I can't get `List-Unsubscribe` to show up despite having followed the guidance at these links:

https://blog.mailtrap.io/list-unsubscribe-header/
https://www.reddit.com/r/postfix/comments/a8p1m7/custom_header/eccyorb?utm_source=share&utm_medium=web2x&context=3

I've been banging my head against this for a while, so if you've got any ideas about the `List-Unsubscribe` header thing, that'd be great. I'm also fine with just forgetting about it given that our updated messages seem no longer to be flagged as spam.