### PR TITLE
Use Git commit hash instead of tag for installing dependencies from GitHub

### DIFF
--- a/apps/topics-base/src/requirements.txt
+++ b/apps/topics-base/src/requirements.txt
@@ -1,5 +1,6 @@
 # Python 3 compatible version of Google's re2 library (requires libre2-dev system package)
-git+https://github.com/andreasvc/pyre2.git@v0.3.2#egg=pyre2
+# (refers to v0.3.2 tag but uses commit hash so that the tag doesn't get updated to something else)
+git+https://github.com/andreasvc/pyre2.git@d48a20aa81a670fa3304a9e3ef6fcb92945c4566#egg=pyre2
 
 # Mocking tweepy responses
 requests_mock==1.8.0


### PR DESCRIPTION
We use pyre2 to speed up regexes. Given that pyre2 isn't published on
Pip, we used to install one of the tagged versions directly from GitHub.

However, there's this new fun way to ruin computer people's mornings out
there:

https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610

Given that one can add and remove Git tags at will, someone
("andreasvc") could have potentially removed the old "v0.3.2" tag, made
their module mine Bitcoin, tagged the updated code as "v0.3.2" and pushed
everything, which would have lead us to unknowingly installing a funky
version of pyre2 in one of our apps.

To the best of my knowledge, one can't update a particular Git commit
hash without the users noticing, but @jtotoole could you have a look as
well?