### PR TITLE
Use a window function instead of a recursive CTE for adding downloads to crawler-fetcher queue, add download IDs in chunks

### DIFF
--- a/apps/crawler-provider/.idea/crawler-provider.iml
+++ b/apps/crawler-provider/.idea/crawler-provider.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="jdk" jdkName="Remote Python 3.7.3 Docker Compose (crawler-provider at [/Users/pypt/Dropbox/etc-MediaCloud/trunk/apps/crawler-provider/docker-compose.tests.yml])" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Remote Python 3.8.5 Docker Compose (crawler-provider at [/home/pypt/m/apps/crawler-provider/docker-compose.tests.yml])" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TestRunnerService">

--- a/apps/crawler-provider/.idea/inspectionProfiles/Project_Default.xml
+++ b/apps/crawler-provider/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="HttpUrlsUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/apps/crawler-provider/.idea/mediawords.sql
+++ b/apps/crawler-provider/.idea/mediawords.sql
@@ -1,0 +1,1 @@
+../../postgresql-server/schema/mediawords.sql

--- a/apps/crawler-provider/.idea/misc.xml
+++ b/apps/crawler-provider/.idea/misc.xml
@@ -6,5 +6,5 @@
   <component name="NodePackageJsonFileManager">
     <packageJsonPaths />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Remote Python 3.7.3 Docker Compose (crawler-provider at [/Users/pypt/Dropbox/etc-MediaCloud/trunk/apps/crawler-provider/docker-compose.tests.yml])" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Remote Python 3.8.5 Docker Compose (crawler-provider at [/home/pypt/m/apps/crawler-provider/docker-compose.tests.yml])" project-jdk-type="Python SDK" />
 </project>

--- a/apps/crawler-provider/.idea/sqldialects.xml
+++ b/apps/crawler-provider/.idea/sqldialects.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="SqlDialectMappings">
+    <file url="file://$PROJECT_DIR$/.idea/mediawords.sql" dialect="PostgreSQL" />
     <file url="file://$PROJECT_DIR$/../postgresql-server/schema/mediawords.sql" dialect="PostgreSQL" />
     <file url="PROJECT" dialect="PostgreSQL" />
   </component>

--- a/apps/crawler-provider/src/python/crawler_provider/__init__.py
+++ b/apps/crawler-provider/src/python/crawler_provider/__init__.py
@@ -15,12 +15,13 @@ once per second.
 
 The provider works as a daemon, periodically checking the size queued_downloads and only adding
 new jobs to the queue if there are more than MAX_QUEUE_SIZE jobs in the table.  This allows us to implement
-throttline by keeping the crawler jobs queue relatively small, thus limiting the number of requests for each
+throttling by keeping the crawler jobs queue relatively small, thus limiting the number of requests for each
 host over a period of several minutes, while allowing the crawler_fetcher jobs to acts as simple stupid
 worker jobs that just do a quick query of queued_downloads to grab the oldest queued download.
 """
 
 import time
+from typing import List
 
 from mediawords.db import DatabaseHandler
 from mediawords.util.log import create_logger
@@ -97,7 +98,7 @@ def _add_stale_feeds(db: DatabaseHandler) -> None:
             -- Feed was downloaded more than stale_feed_interval seconds ago
             OR (last_attempted_download_time < (NOW() - (%(a)s || ' seconds')::interval))
 
-            -- (Probably) if a new story comes in every "n" seconds, refetch feed every "n" + 5 minutes
+            -- (Probably) if a new story comes in every "n" seconds, re-fetch feed every "n" + 5 minutes
             OR (
                 (NOW() > last_attempted_download_time +
                         (last_attempted_download_time - last_new_story_time) + interval '5 minutes')

--- a/apps/crawler-provider/src/python/crawler_provider/__init__.py
+++ b/apps/crawler-provider/src/python/crawler_provider/__init__.py
@@ -114,11 +114,13 @@ def _add_stale_feeds(db: DatabaseHandler) -> None:
 
     db.query(
         """
+        -- noinspection SqlResolve @ table/"feeds_to_queue"
         UPDATE feeds
         SET last_attempted_download_time = NOW()
         WHERE feeds_id IN (SELECT feeds_id FROM feeds_to_queue)
         """)
 
+    # noinspection SqlResolve,SqlCheckUsingColumns
     downloads = db.query(
         """
         WITH inserted_downloads as (
@@ -141,7 +143,10 @@ def _add_stale_feeds(db: DatabaseHandler) -> None:
                 join feeds f using (feeds_id)
         """).hashes()
 
-    db.query("drop table feeds_to_queue")
+    db.query("""
+        -- noinspection SqlResolveForFile
+        drop table feeds_to_queue
+    """)
 
     log.info("added stale feeds: %d" % len(downloads))
 

--- a/apps/crawler-provider/src/python/crawler_provider/__init__.py
+++ b/apps/crawler-provider/src/python/crawler_provider/__init__.py
@@ -152,7 +152,7 @@ def _add_stale_feeds(db: DatabaseHandler) -> None:
     log.info(f"Added stale feeds: {len(downloads)}")
 
 
-def provide_download_ids(db: DatabaseHandler) -> None:
+def provide_download_ids(db: DatabaseHandler) -> List[int]:
     """Return a list of pending downloads ids to queue for fetching.
 
     Hand out one downloads_id for each distinct host with a pending download.

--- a/apps/crawler-provider/src/python/crawler_provider/__init__.py
+++ b/apps/crawler-provider/src/python/crawler_provider/__init__.py
@@ -148,7 +148,7 @@ def _add_stale_feeds(db: DatabaseHandler) -> None:
         drop table feeds_to_queue
     """)
 
-    log.info("added stale feeds: %d" % len(downloads))
+    log.info(f"Added stale feeds: {len(downloads)}")
 
 
 def provide_download_ids(db: DatabaseHandler) -> None:
@@ -163,13 +163,13 @@ def provide_download_ids(db: DatabaseHandler) -> None:
 
     _add_stale_feeds(db)
 
-    log.info("querying pending downloads ...")
+    log.info("Querying pending downloads...")
 
     # get one downloads_id per host, ordered by priority asc, downloads_id desc, do this through a plpgsql
     # function because that's the only way to avoid an index scan of the entire (host, priority, downloads_id) index
     downloads_ids = db.query("select get_downloads_for_queue() downloads_id").flat()
 
-    log.info("provide downloads host downloads: %d" % len(downloads_ids))
+    log.info(f"Provide downloads host downloads: {len(downloads_ids)}")
 
     return downloads_ids
 
@@ -194,13 +194,13 @@ def run_provider(db: DatabaseHandler, daemon: bool = True) -> None:
         queue_size = db.query(
             "select count(*) from ( select 1 from queued_downloads limit %(a)s ) q",
             {'a': MAX_QUEUE_SIZE * 10}).flat()[0]
-        log.warning("queue_size: %d" % queue_size)
+        log.warning(f"Queue size: {queue_size}")
 
         if queue_size < MAX_QUEUE_SIZE:
             downloads_ids = provide_download_ids(db)
 
             if downloads_ids:
-                log.warning("adding to downloads to queue: %d" % len(downloads_ids))
+                log.info(f"Adding to downloads to queue: {len(downloads_ids)}")
 
                 values = ','.join(["(%d)" % i for i in downloads_ids])
                 db.query(

--- a/apps/crawler-provider/tests/python/test_add_stale_feeds.py
+++ b/apps/crawler-provider/tests/python/test_add_stale_feeds.py
@@ -3,6 +3,8 @@ import time
 from mediawords.test.db.create import create_test_medium
 from mediawords.db import connect_to_db
 from mediawords.util.sql import sql_now, get_sql_date_from_epoch
+
+# noinspection PyProtectedMember
 from crawler_provider import _add_stale_feeds
 
 
@@ -32,7 +34,7 @@ def test_add_stale_feeds():
         'active': True,
         'last_attempted_download_time': sql_now()
     }
-    feed = db.create('feeds', feed)
+    db.create('feeds', feed)
 
     feed = {
         'media_id': medium['media_id'],
@@ -43,7 +45,7 @@ def test_add_stale_feeds():
         'last_attempted_download_time': sql_now(),
         'last_new_story_time': sql_now()
     }
-    feed = db.create('feeds', feed)
+    db.create('feeds', feed)
 
     feed = {
         'media_id': medium['media_id'],
@@ -51,8 +53,8 @@ def test_add_stale_feeds():
         'url': 'http://5 minute new story',
         'type': 'syndicated',
         'active': True,
-        'last_attempted_download_time': get_sql_date_from_epoch(time.time() - 300),
-        'last_new_story_time': get_sql_date_from_epoch(time.time() - 300),
+        'last_attempted_download_time': get_sql_date_from_epoch(int(time.time()) - 300),
+        'last_new_story_time': get_sql_date_from_epoch(int(time.time()) - 300),
     }
     feed = db.create('feeds', feed)
     pending_feeds.append(feed)
@@ -63,7 +65,7 @@ def test_add_stale_feeds():
         'url': 'http://old last download',
         'type': 'syndicated',
         'active': True,
-        'last_attempted_download_time': get_sql_date_from_epoch(time.time() - (86400 * 10))
+        'last_attempted_download_time': get_sql_date_from_epoch(int(time.time()) - (86400 * 10))
     }
     feed = db.create('feeds', feed)
     pending_feeds.append(feed)

--- a/apps/crawler-provider/tests/python/test_provide_download_ids.py
+++ b/apps/crawler-provider/tests/python/test_provide_download_ids.py
@@ -1,5 +1,6 @@
 from mediawords.db import connect_to_db
 from mediawords.test.db.create import create_test_medium, create_test_feed
+
 from crawler_provider import provide_download_ids
 
 

--- a/apps/crawler-provider/tests/python/test_run_provider.py
+++ b/apps/crawler-provider/tests/python/test_run_provider.py
@@ -1,8 +1,9 @@
 import time
 
-from crawler_provider import run_provider
 from mediawords.test.db.create import create_test_medium, create_test_feed
 from mediawords.db import connect_to_db
+
+from crawler_provider import run_provider
 
 
 def test_run_provider():

--- a/apps/postgresql-server/schema/mediawords.sql
+++ b/apps/postgresql-server/schema/mediawords.sql
@@ -26,7 +26,7 @@ CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
 DECLARE
     -- Database schema version number (same as a SVN revision number)
     -- Increase it by 1 if you make major database schema changes.
-    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4759;
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4760;
 BEGIN
 
     -- Update / set database schema version
@@ -1492,42 +1492,6 @@ end;
 
 $$ language plpgsql;
 
--- efficiently query downloads_pending for the latest downloads_id per host.  postgres is not able to do this through
--- its normal query planning (it just does an index scan of the whole index).  this turns a query that 
--- takes ~22 seconds for a 100 million row table into one that takes ~0.25 seconds
-create or replace function get_downloads_for_queue() returns table(downloads_id bigint) as $$
-declare
-    pending_host record;
-begin
-    -- quick temp copy without dead row issues for querying in loop body below
-    create temporary table qd on commit drop as select * from queued_downloads;
-
-    create temporary table pending_downloads (downloads_id bigint) on commit drop;
-    for pending_host in
-            WITH RECURSIVE t AS (
-               (SELECT host FROM downloads_pending ORDER BY host LIMIT 1)
-               UNION ALL
-               SELECT (SELECT host FROM downloads_pending WHERE host > t.host ORDER BY host LIMIT 1)
-               FROM t
-               WHERE t.host IS NOT NULL
-               )
-            SELECT host FROM t WHERE host IS NOT NULL
-        loop
-            insert into pending_downloads
-                select dp.downloads_id
-                    from downloads_pending dp
-                        left join qd on ( dp.downloads_id = qd.downloads_id )
-                    where 
-                        host = pending_host.host and
-                        qd.downloads_id is null
-                    order by priority, downloads_id desc nulls last
-                    limit 1;
-        end loop;
-
-    return query select pd.downloads_id from pending_downloads pd;
- end;
-
-$$ language plpgsql;
 
 --
 -- Extracted plain text from every download

--- a/apps/postgresql-server/schema/migrations/mediawords-4759-4760.sql
+++ b/apps/postgresql-server/schema/migrations/mediawords-4759-4760.sql
@@ -1,0 +1,44 @@
+--
+-- This is a Media Cloud PostgreSQL schema difference file (a "diff") between schema
+-- versions 4759 and 4760.
+--
+-- If you are running Media Cloud with a database that was set up with a schema version
+-- 4759, and you would like to upgrade both the Media Cloud and the
+-- database to be at version 4760, import this SQL file:
+--
+--     psql mediacloud < mediawords-4759-4760.sql
+--
+-- You might need to import some additional schema diff files to reach the desired version.
+--
+--
+-- 1 of 2. Import the output of 'apgdiff':
+--
+
+
+
+
+
+--
+-- 2 of 2. Reset the database version.
+--
+
+CREATE OR REPLACE FUNCTION set_database_schema_version() RETURNS boolean AS $$
+DECLARE
+
+    -- Database schema version number (same as a SVN revision number)
+    -- Increase it by 1 if you make major database schema changes.
+    MEDIACLOUD_DATABASE_SCHEMA_VERSION CONSTANT INT := 4760;
+
+BEGIN
+
+    -- Update / set database schema version
+    DELETE FROM database_variables WHERE name = 'database-schema-version';
+    INSERT INTO database_variables (name, value) VALUES ('database-schema-version', MEDIACLOUD_DATABASE_SCHEMA_VERSION::int);
+
+    return true;
+
+END;
+$$
+LANGUAGE 'plpgsql';
+
+SELECT set_database_schema_version();


### PR DESCRIPTION
On Friday evening (of course!), crawler has decided that it doesn't feel like fetching feeds / stories anymore.

Short intro into how everything works:

* `crawler-provider` decides which feeds / stories / downloads are due to be fetched and adds them to `queued_downloads` table;
* `crawler-fetcher` polls the `queued_downloads` table to find the downloads to fetch.

`crawler-provider` has to identify which downloads from `downloads_pending` table it has to get enqueued for fetching, but it has to add only one download per host (e.g. one download for `nytimes.com`) to the `queued_downloads` table so that the fetchers don't end up fetching 1000 URLs from a single host in parallel. It used to do this task with the following plpgsql function:

```sql
-- efficiently query downloads_pending for the latest downloads_id per host.  postgres is not able to do this through
-- its normal query planning (it just does an index scan of the whole index).  this turns a query that 
-- takes ~22 seconds for a 100 million row table into one that takes ~0.25 seconds
create or replace function get_downloads_for_queue() returns table(downloads_id bigint) as $$
declare
    pending_host record;
begin
    -- quick temp copy without dead row issues for querying in loop body below
    create temporary table qd on commit drop as select * from queued_downloads;

    create temporary table pending_downloads (downloads_id bigint) on commit drop;
    for pending_host in
            WITH RECURSIVE t AS (
               (SELECT host FROM downloads_pending ORDER BY host LIMIT 1)
               UNION ALL
               SELECT (SELECT host FROM downloads_pending WHERE host > t.host ORDER BY host LIMIT 1)
               FROM t
               WHERE t.host IS NOT NULL
               )
            SELECT host FROM t WHERE host IS NOT NULL
        loop
            insert into pending_downloads
                select dp.downloads_id
                    from downloads_pending dp
                        left join qd on ( dp.downloads_id = qd.downloads_id )
                    where 
                        host = pending_host.host and
                        qd.downloads_id is null
                    order by priority, downloads_id desc nulls last
                    limit 1;
        end loop;

    return query select pd.downloads_id from pending_downloads pd;
 end;

$$ language plpgsql;
```

The function:

1. Read unique (distinct) `host`s from `downloads_pending` one by one;
2. Fetched the most prioritized download from `downloads_pending` individually.

I think it was implemented like that due to some sort of a performance reason (sometimes it's hard to make PostgreSQL use its indexes in the most efficient manner). Whatever the reasoning, the function took 2 hours to complete on every run which made it infeasible, so I've simplified things by making `crawler-provider` run a [window function](https://stackoverflow.com/a/3800572).

Also, upon collecting download IDs to fetch (after two hours), `crawler-fetcher` used to aggregate them all into a single string to later insert into `queued_downloads`:

```sql
values = ','.join(["(%d)" % i for i in downloads_ids])
db.query(
    "insert into queued_downloads(downloads_id) values %s on conflict (downloads_id) do nothing" %
    values)
```

Two problems here:

1. Our database handler accepts Python `list`s as parameters which it then turns into PostgreSQL `ARRAY[]`s so we can capitalize on that fact and make things simpler;
2. More importantly, if you so happen to have a lot (tens, hundreds of thousands) of download IDs to be inserted, the code above will generate a single massive SQL query which will take ages to parse, run, and most probably will just fail.

So, now the list of download IDs get split into chunks of a thousand each and inserted separately.

@jtotoole could you please have a look at this one? It's already deployed (to not lose stories over the weekend) but maybe I've made errors in my plpgsql -> window function rewrite. This one very much is in need of a second pair of eyes because it's the critical path of our codebase.
