### PR TITLE
Fix test_snapshot_prune.t

### DIFF
--- a/apps/topics-snapshot/docker-compose.tests.yml
+++ b/apps/topics-snapshot/docker-compose.tests.yml
@@ -57,6 +57,9 @@ services:
         image: gcr.io/mcback/topics-map:latest
         init: true
         stop_signal: SIGKILL
+        environment:
+            MC_PUBLIC_STORE_TYPE: "postgresql"
+            MC_PUBLIC_STORE_SALT: "foo"
         volumes:
             - type: bind
               source: ./../topics-map/bin/

--- a/apps/topics-snapshot/src/perl/MediaWords/TM/Snapshot.pm
+++ b/apps/topics-snapshot/src/perl/MediaWords/TM/Snapshot.pm
@@ -922,16 +922,6 @@ SQL
     }
     else
     {
-#         say STDERR "PRUNING STORIES";
-
-#         say STDERR "All topic links: " . Dumper( $db->query( <<SQL,
-#             select cs.*
-#         from topic_stories cs
-#         where cs.topics_id = ?
-# SQL
-#             $topic->{ topics_id }
-#         )->hashes() );
-
         $db->query( <<SQL, $topic->{ topics_id } );
 create temporary table snapshot_topic_stories as 
 

--- a/apps/topics-snapshot/src/perl/MediaWords/TM/Snapshot.pm
+++ b/apps/topics-snapshot/src/perl/MediaWords/TM/Snapshot.pm
@@ -922,6 +922,16 @@ SQL
     }
     else
     {
+#         say STDERR "PRUNING STORIES";
+
+#         say STDERR "All topic links: " . Dumper( $db->query( <<SQL,
+#             select cs.*
+#         from topic_stories cs
+#         where cs.topics_id = ?
+# SQL
+#             $topic->{ topics_id }
+#         )->hashes() );
+
         $db->query( <<SQL, $topic->{ topics_id } );
 create temporary table snapshot_topic_stories as 
 

--- a/apps/topics-snapshot/tests/perl/test_snapshot_prune.t
+++ b/apps/topics-snapshot/tests/perl/test_snapshot_prune.t
@@ -139,15 +139,24 @@ SQL
         $tsu = $db->create( 'topic_seed_urls', $tsu );
     }
 
+    say STDERR "All snapshots before snapshot_topic: " . Dumper( $db->query( "select * from snapshots where topics_id = ?", $topic->{ topics_id } )->hashes() );
+
     MediaWords::TM::Snapshot::snapshot_topic( $db, $topics_id );
+
+    say STDERR "All snapshots after snapshot_topic: " . Dumper( $db->query( "select * from snapshots where topics_id = ?", $topic->{ topics_id } )->hashes() );
 
     my $got_snapshot = $db->query( "select * from snapshots where topics_id = ?", $topic->{ topics_id } )->hash;
 
     ok( $got_snapshot, "snapshot exists" );
 
+    say STDERR Dumper( $got_snapshot );
+
     my $got_stories = $db->query( <<SQL, $got_snapshot->{ snapshots_id } )->hashes;
 select * from snap.stories where snapshots_id = ?
 SQL
+
+    say STDERR Dumper( $got_stories );
+
 
     is( scalar( @{ $got_stories } ), 2, "number of pruned stories" );
 }

--- a/apps/topics-snapshot/tests/perl/test_snapshot_prune.t
+++ b/apps/topics-snapshot/tests/perl/test_snapshot_prune.t
@@ -139,24 +139,15 @@ SQL
         $tsu = $db->create( 'topic_seed_urls', $tsu );
     }
 
-    say STDERR "All snapshots before snapshot_topic: " . Dumper( $db->query( "select * from snapshots where topics_id = ?", $topic->{ topics_id } )->hashes() );
-
     MediaWords::TM::Snapshot::snapshot_topic( $db, $topics_id );
-
-    say STDERR "All snapshots after snapshot_topic: " . Dumper( $db->query( "select * from snapshots where topics_id = ?", $topic->{ topics_id } )->hashes() );
 
     my $got_snapshot = $db->query( "select * from snapshots where topics_id = ?", $topic->{ topics_id } )->hash;
 
     ok( $got_snapshot, "snapshot exists" );
 
-    say STDERR Dumper( $got_snapshot );
-
     my $got_stories = $db->query( <<SQL, $got_snapshot->{ snapshots_id } )->hashes;
 select * from snap.stories where snapshots_id = ?
 SQL
-
-    say STDERR Dumper( $got_stories );
-
 
     is( scalar( @{ $got_stories } ), 2, "number of pruned stories" );
 }

--- a/apps/topics-snapshot/tests/perl/test_snapshot_prune.t
+++ b/apps/topics-snapshot/tests/perl/test_snapshot_prune.t
@@ -139,13 +139,13 @@ SQL
         $tsu = $db->create( 'topic_seed_urls', $tsu );
     }
 
-    MediaWords::TM::Snapshot::snapshot_topic( $db, $topics_id );
+    my $new_snapshots_id = MediaWords::TM::Snapshot::snapshot_topic( $db, $topics_id );
 
-    my $got_snapshot = $db->query( "select * from snapshots where topics_id = ?", $topic->{ topics_id } )->hash;
+    my $got_snapshot = $db->query( "select * from snapshots where snapshots_id = ?", $new_snapshots_id )->hash;
 
     ok( $got_snapshot, "snapshot exists" );
 
-    my $got_stories = $db->query( <<SQL, $got_snapshot->{ snapshots_id } )->hashes;
+    my $got_stories = $db->query( <<SQL, $new_snapshots_id )->hashes;
 select * from snap.stories where snapshots_id = ?
 SQL
 


### PR DESCRIPTION
I started off my debugging by looking into logs of all containers that get started for running the test. If you just do:

```bash
./dev/run_test.py ./apps/topics-snapshot/tests/perl/test_snapshot_prune.t
```

Docker will create a bunch of containers for all of the services started in `docker-compose.tests.yml`, run the test, print out its result and destroy off all of the containers, so it might be a bit hard to find out the log of, say, `topics-map` service which gets started as part of the `topics-snapshot`'s `docker-compose.tests.yml`.

But as per the docs, you can pass the `-p` flag to any of the scripts in `./dev/` for them to print commands that it's about to run instead of actually running. This way you can start a testing environment, run the test manually, and then go have a look at the logs of other services while the test environment is still "up":

```bash
$ ./dev/run_test.py -p ./apps/topics-snapshot/tests/perl/test_snapshot_prune.t
/home/pypt/Dropbox/etc-MediaCloud/trunk/dev/run.py --all_apps_dir /home/pypt/Dropbox/etc-MediaCloud/trunk/apps topics-snapshot -- prove /opt/mediacloud/tests/perl/test_snapshot_prune.t
```

So basically `./dev/run_test.py` executes `./dev/run.py` with either `prove` (for Perl tests) or `py.test` (for Python tests).

I have then started the testing environment and ran the `prove /opt/.../test_snapshot_prune.t` manually:

```bash
$ ./dev/run.py topics-snapshot bash
mediacloud@cf0e661c7777:/$ prove /opt/mediacloud/tests/perl/test_snapshot_prune.t
<...>
#   Failed test 'number of pruned stories'
#   at /opt/mediacloud/tests/perl/test_snapshot_prune.t line 161.
#          got: '0'
#     expected: '2'
# Looks like you failed 1 test of 2.
/opt/mediacloud/tests/perl/test_snapshot_prune.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests 

Test Summary Report
-------------------
/opt/mediacloud/tests/perl/test_snapshot_prune.t (Wstat: 256 Tests: 2 Failed: 1)
  Failed test:  2
  Non-zero exit status: 1
Files=1, Tests=2,  7 wallclock secs ( 0.05 usr  0.02 sys +  2.64 cusr  0.29 csys =  3.00 CPU)
Result: FAIL
ERROR: 1
Subprocess returned non-zero exit status 1.
Traceback (most recent call last):
  File "/home/pypt/Dropbox/etc-MediaCloud/trunk/./dev/run_test.py", line 162, in <module>
    subprocess.check_call(command_)
  File "/usr/lib/python3.9/subprocess.py", line 373, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/pypt/Dropbox/etc-MediaCloud/trunk/dev/run.py', '--all_apps_dir', '/home/pypt/Dropbox/etc-MediaCloud/trunk/apps', 'topics-snapshot', '--', 'prove', '/opt/mediacloud/tests/perl/test_snapshot_prune.t']' returned non-zero exit status 1.
mediacloud@cf0e661c7777:/$ 
```

While the test environment still on, I've checked logs of other containers (`docker log`) and this is how I found out about some unset environment variables fixed in fed5a70.

That turned out to not be the fix for the original problem though. Last time all of the tests worked was in your `jot-update-stopwords` branch so I've checked that out, added a bunch of debugging messages and ran the tests.

It turned out that the test creates two snapshots (two rows in the `snapshots` table) and then in:

https://github.com/mediacloud/backend/blob/019e608ffccc7a62ee458fdaa4e53d5ea98c8e21/apps/topics-snapshot/tests/perl/test_snapshot_prune.t#L144-L150

it fetches all (= two) snapshots without any kind of ordering (`ORDER BY`) set up, and uses only the first received row (because `->hash()` method in Perl / `.hash()` method in Python returns only a single row). PostgreSQL doesn't have any default ordering, i.e. if you don't specify `ORDER BY`, it is free to return rows in any order, so before it used to return snapshot with `snapshots_id = 2` first by default, and since then it has changed its mind and started returning snapshot with `snapshots_id = 1` first :)

So, given that `snapshot_topic()` returns an ID of the created snapshot, and the subsequent test code expects that specific snapshot that just got created, I've made the query return that one specific snapshot instead.

If the fix looks good to you, go ahead and merge it into `master`.

Fixes #795
