### PR TITLE
drop cliff_ + nytlabels_annotations tables via pgmigrate

### DIFF
--- a/apps/postgresql-server/pgmigrate/migrations/V0004__drop_annotations_tables.sql
+++ b/apps/postgresql-server/pgmigrate/migrations/V0004__drop_annotations_tables.sql
@@ -1,0 +1,5 @@
+TRUNCATE cliff_annotations;
+DROP TABLE cliff_annotations;
+
+TRUNCATE nytlabels_annotations;
+DROP TABLE nytlabels_annotations;


### PR DESCRIPTION
relates to https://github.com/mediacloud/backend/issues/743