### PR TITLE
Fix typo in path to pgmigrate migrations

### DIFF
--- a/apps/postgresql-server/bin/apply_migrations.sh
+++ b/apps/postgresql-server/bin/apply_migrations.sh
@@ -7,7 +7,7 @@ MC_POSTGRESQL_BIN_DIR="/usr/lib/postgresql/13/bin/"
 MC_POSTGRESQL_DATA_DIR="/var/lib/postgresql/13/main/"
 MC_POSTGRESQL_CONF_PATH="/etc/postgresql/13/main/postgresql.conf"
 
-MIGRATIONS_DIR="/opt/postgresql-server/pgmigratemigrations"
+MIGRATIONS_DIR="/opt/postgresql-server/pgmigrate/migrations"
 
 # Apply migrations when running on a different port so that clients don't end
 # up connecting in the middle of migrating


### PR DESCRIPTION
Migrations don't get applied on first run of the container so this wasn't caught by the CI.

A simple way to make sure that migrations work is to start some sort of a test Compose layout, e.g.:

```bash
./dev/run.py common bash
```

and then restart the postgresql-server container:

```bash
docker restart $(docker ps | grep postgresql-server | awk '{ print $1 }')
```