### PR TITLE
Lock Docker Python module's and docker-compose's versions

### DIFF
--- a/provision/roles/docker/tasks/dockerd.yml
+++ b/provision/roles/docker/tasks/dockerd.yml
@@ -191,7 +191,7 @@
 # For Ansible to be able to manage Docker swarms and such
 - name: "Install 'docker' Python module"
   pip:
-    name: docker==3.7.3
+    name: "docker=={{ docker_python_module_version }}"
     state: present
     executable: /usr/bin/pip3
   become: true
@@ -202,7 +202,7 @@
 
 - name: Install docker-compose
   pip:
-    name: docker-compose>=1.22.0
+    name: "docker-compose=={{ docker_compose_version }}"
     state: present
     executable: /usr/bin/pip3
   become: true

--- a/provision/roles/docker/tasks/dockerd.yml
+++ b/provision/roles/docker/tasks/dockerd.yml
@@ -103,8 +103,7 @@
     state: present
     install_recommends: false
     
-    # Workaround to enable --allow-downgrades
-    # (systems that are being deployed to might have a newer version(s) installed)
+    # Workaround to enable --allow-downgrades / --allow-upgrades
     force: true
     force_apt_get: true
 

--- a/provision/roles/docker/vars/dockerd.yml
+++ b/provision/roles/docker/vars/dockerd.yml
@@ -11,6 +11,18 @@
 docker_version: "20.10.8"
 containerd_io_version: "1.4.9-1"
 
+# Docker Python module, needed by Ansible:
+#
+# https://pypi.org/project/docker/#history
+#
+docker_python_module_version: "5.0.0"
+
+# Docker Compose:
+#
+# https://pypi.org/project/docker-compose/#history
+#
+docker_compose_version: "1.29.2"
+
 #
 # Docker daemon configuration
 #


### PR DESCRIPTION
On production (and usually on dev machines too) we want to run specific versions of Docker and related tools (containerd, Docker Python module used by Ansible, Docker Compose) as the newer versions sometimes introduce breaking changes.