### PR TITLE
Use testmediacloud.tk instead of testmediacloud.ml

### DIFF
--- a/apps/mail-postfix-server/docker-compose.tests.yml
+++ b/apps/mail-postfix-server/docker-compose.tests.yml
@@ -47,7 +47,7 @@ services:
         # To be able to set /proc/sys/kernel/yama/ptrace_scope:
         privileged: true
         environment:
-            MC_MAIL_POSTFIX_FQDN: "mail.testmediacloud.ml"
+            MC_MAIL_POSTFIX_FQDN: "mail.testmediacloud.tk"
         depends_on:
             - mail-opendkim-server
         networks:
@@ -59,7 +59,7 @@ services:
         image: gcr.io/mcback/mail-opendkim-server:latest
         init: true
         environment:
-            MC_MAIL_OPENDKIM_DOMAIN: "testmediacloud.ml"
+            MC_MAIL_OPENDKIM_DOMAIN: "testmediacloud.tk"
         expose:
             - "12301"
         volumes:

--- a/apps/munin-cron/docker-compose.tests.yml
+++ b/apps/munin-cron/docker-compose.tests.yml
@@ -7,7 +7,7 @@ services:
         init: true
         stop_signal: SIGKILL
         environment:
-            MC_MUNIN_CRON_ALERT_EMAIL: "alerts@testmediacloud.ml"
+            MC_MUNIN_CRON_ALERT_EMAIL: "alerts@testmediacloud.tk"
         volumes:
             - type: bind
               source: ./munin-conf.d/host.conf


### PR DESCRIPTION
`testmediacloud` is our test domain that we use for testing DNS changes,
e.g. IPv6 addressing to LXC containers, email sending / receiving etc.

Domain is registered on Freenom.com. The `.ml` version expired, and they
wanted 8 EUR for a renewal, so I went with `.tk` which was free.

[ci skip]